### PR TITLE
added the capital gains tax calculation and implementation

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -4,19 +4,28 @@
   let yearlyIncome = 0;
   let year = '2022';
   let marrStatus = 'single';
+  let capGainsMarrStatus = 'LT_capital_gains_' + marrStatus;
   let taxes = 0;
   let afterTax = 0;
+  let capitalGainsShortTerm = 0;
+  let capitalGainsLongTerm = 0;
+  //let hasCapital = false;
 
   // @ts-ignore
   function calcTaxes() {
-      let intIncome = yearlyIncome;
+      let shortTermCapGains = capitalGainsShortTerm;
+      let longTermGapGains = capitalGainsLongTerm;
+      let intIncome = yearlyIncome + capitalGainsShortTerm; //short-term cap gains tax is considered as part of your yearly income
+      
       let curr_taxes = 0;
 
       // grab correct tax data for year
       // @ts-ignore
       let currMap = tax_data.yearToTax[year];
       let rates = currMap["percents"];
+      let capGainsRates = currMap["LT_capital_gains_percents"]
       let salaries = currMap[marrStatus];
+      let capGains = currMap[capGainsMarrStatus];
       let govtSpendingPercents = currMap["budget_percents"];
 
       // calculate income tax
@@ -31,6 +40,23 @@
       if (intIncome > salaries[salaries.length-1]) {
           curr_taxes += (intIncome - salaries[salaries.length-1])*rates[rates.length-1];
       }
+      
+      // calculate long-term capital gains tax
+      let capitalGainsLongTermTax = 0;
+
+      for (let i = 1; i < capGains.length; i++) {
+          if (capitalGainsLongTerm >= capGains[i]) {
+            capitalGainsLongTermTax += (capGains[i] - capGains[i-1])*capGainsRates[i-1];
+          } else {
+              capitalGainsLongTermTax += (capitalGainsLongTerm - capGains[i - 1])*capGainsRates[i-1];
+          break;
+          }
+      }
+      if (capitalGainsLongTerm > capGains[capGains.length-1]) {
+        capitalGainsLongTermTax += (capitalGainsLongTerm - capGains[capGains.length-1])*capGainsRates[capGainsRates.length-1];
+      }
+
+
 
       // calculate fica
       let socSec = 0;
@@ -64,8 +90,11 @@
       }
 
       // update tax info
-      taxes = curr_taxes + socSec + medicare;
-      afterTax = intIncome - taxes;
+      taxes = curr_taxes + socSec + medicare + capitalGainsLongTermTax;
+
+      // according to ChatGPT (very reputable source ikik),
+      // LT capital gains is reported as part of your income, even though they're taxed differently
+      afterTax = (capitalGainsLongTerm - capitalGainsLongTermTax) + intIncome - taxes;
       return yearlyIncome;
       // TODO: code that fills in chart.js data
       /*let yourPayments = [medicare, socSec]
@@ -102,6 +131,10 @@ let answer = '';
               </option>
           {/each}
       </select>
+      <label for="fname">Short-Term Capital Gains:</label>
+      <input type="number" class = "income-entry" bind:value={capitalGainsShortTerm} on:input={calcTaxes}><br><br>
+      <label for="fname">Long-Term Capital Gains:</label>
+      <input type="number" class = "income-entry" bind:value={capitalGainsLongTerm} on:input={calcTaxes}><br><br>
       <br>
       <br>
       <input type="submit" value="Calculate Taxes!">

--- a/src/lib/data.js
+++ b/src/lib/data.js
@@ -55,7 +55,12 @@ export const mappings2018 = {
 .0060,
 .0045,
 .0029,
-.0069,]
+.0069,],
+"LT_capital_gains_percents": [0., .15, .2],
+"LT_capital_gains_single": [0, 38700, 426700],
+"LT_capital_gains_seperate": [0, 38700, 240025],
+"LT_capital_gains_together": [0, 77400, 480050],
+"LT_capital_gains_head": [0, 51850, 453350]
 };
 
 export const mappings2019 = {
@@ -85,7 +90,12 @@ export const mappings2019 = {
 .0059,
 .0061,
 .0037,
-.0048,]
+.0048,],
+"LT_capital_gains_percents": [0., .15, .2],
+"LT_capital_gains_single": [0, 39376, 434550],
+"LT_capital_gains_seperate": [0, 39376, 244425],
+"LT_capital_gains_together": [0, 78751, 488850],
+"LT_capital_gains_head": [0, 52751, 461700]
 };
 
 export const mappings2020 = {
@@ -95,7 +105,12 @@ export const mappings2020 = {
 "together": [0, 19750, 80250, 171050, 326600, 414700, 622050],
 "head": [0, 14100, 53700, 85500, 163300, 207350, 518400],
 "ss": 137700,
-"budget_percents": [0.1452, 0.1261, 0.1203, 0.1038, 0.1592, 0.0604, 0.0649, 0.0269, 0.0102, 0.0313, 0.0215, 0.0201, 0.0084, 0.0101, 0.0714, 0.0045, 0.0045, 0.0034, 0.0077]
+"budget_percents": [0.1452, 0.1261, 0.1203, 0.1038, 0.1592, 0.0604, 0.0649, 0.0269, 0.0102, 0.0313, 0.0215, 0.0201, 0.0084, 0.0101, 0.0714, 0.0045, 0.0045, 0.0034, 0.0077],
+"LT_capital_gains_percents": [0., .15, .2],
+"LT_capital_gains_single": [0, 40000, 441450],
+"LT_capital_gains_seperate": [0, 40000, 248300],
+"LT_capital_gains_together": [0, 80000, 496600],
+"LT_capital_gains_head": [0, 53600, 469050]
 };
 
 export const mappings2021 = {
@@ -105,7 +120,12 @@ export const mappings2021 = {
 "together": [0, 19900, 81050, 172750, 329850, 418850, 628301],
 "head": [0, 14200, 54200, 86350, 164900, 209400, 523600],
 "ss": 142800,
-"budget_percents": [.1374, .1178, .1111, .0998, .1987, .0576, .0696, .0256, .0195, .0505, .0218, .0125, .0078, .0087, .0387, .0041, .0036, .0018, .0131]
+"budget_percents": [.1374, .1178, .1111, .0998, .1987, .0576, .0696, .0256, .0195, .0505, .0218, .0125, .0078, .0087, .0387, .0041, .0036, .0018, .0131],
+"LT_capital_gains_percents": [0., .15, .2],
+"LT_capital_gains_single": [0, 40400, 445850],
+"LT_capital_gains_seperate": [0, 40400, 250800],
+"LT_capital_gains_together": [0, 80800, 501600],
+"LT_capital_gains_head": [0, 54100, 473750]
 };
 
 export const mappings2022 = {
@@ -115,7 +135,12 @@ export const mappings2022 = {
 "together": [0, 20550, 83550, 178150, 340100, 431900, 647850],
 "head": [0, 14650, 55900, 89050, 170050, 215950, 539900],
 "ss": 147000,
-"budget_percents": [.1649, .1528, .1395, .1305, .104, .0894, .0513, .033, .0094, .0254, .0332, .0111, .0098, .0106, .0086, .0049, .0037, .0019, .016]
+"budget_percents": [.1649, .1528, .1395, .1305, .104, .0894, .0513, .033, .0094, .0254, .0332, .0111, .0098, .0106, .0086, .0049, .0037, .0019, .016],
+"LT_capital_gains_percents": [0., .15, .2],
+"LT_capital_gains_single": [0, 41675, 459750],
+"LT_capital_gains_seperate": [0, 41675, 258600],
+"LT_capital_gains_together": [0, 83350, 517200],
+"LT_capital_gains_head": [0, 55800, 488500]
 };
 
 export const yearToTax = {


### PR DESCRIPTION
In my code, I added an implementation for calculating and displaying capital gains tax. The way I went about it was by splitting capital gains tax into short-term (gain on assets that are sold within 1 year of purchase, like stocks) and long-term (gain on assets sold after more than one year of purchase, like a house). According to my research, short-term capital gains are treated as a source of annual income, and so are taxed in the same tax-bracket scheme as every other income. To handle this, I just set the 'intIncome' variable in calcTaxes() to be equal to general income + short-term capital gains. For long-term capital gains, they gave their own separate tax bracket scheme, so I added fields in the map for each year for the percents [0, 0.15, 0.2] and the values your assets have to be at to qualify in each bucket. After that, it's pretty much the same code structure that calculates income tax. I added two input fields for short-term and long-term capital gains respectively, and from the testing I've done, it seems to be calculating the after-tax income correctly, although I'd really appreciate it if someone could check the results for me (I calculate on afterTax = (capitalGainsLongTerm - capitalGainsLongTermTax) + intIncome - taxes; on line 97 in App.svelte just because it didn't make sense to make a profit on your capital gains but still have an after-tax loss). 