### PR TITLE
done

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -64,15 +64,12 @@
 
         // Update tax info
         totalTaxes = incomeTaxes + socialSecurityTaxes + medicareTaxes - nonRefundableTaxCredit;
-        if (totalTaxes < 0) {
-            totalTaxes = 0;
-        }
-        afterTaxIncome = grossIncome - totalTaxes;
+        totalTaxes = Math.max(totalTaxes, 0);
         totalTaxes -= refundableTaxCredit;
-        if (totalTaxes < 0) {
-            afterTaxIncome -= totalTaxes;
-            totalTaxes = 0;
-        }
+        incomeTaxes -= nonRefundableTaxCredit;
+        incomeTaxes = Math.max(incomeTaxes, 0);
+        incomeTaxes -= refundableTaxCredit;
+        afterTaxIncome = grossIncome - totalTaxes;
 
         // Return grossIncome, which prevents variable from being changed on form submission
         return grossIncome;
@@ -129,5 +126,11 @@
   }
   .income-entry {
       width: 50%;
+  }
+  .refundable-entry {
+    width: 10%;
+  }
+  .nonrefundable-entry {
+    width: 10%;
   }
 </style>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,6 +8,8 @@
     let year = '2022';
     let marrStatus = 'Single';
     let grossIncome = 0;
+    let refundableTaxCredit = 0;
+    let nonRefundableTaxCredit = 0;
     let prevGrossIncome = 0;
     let afterTaxIncome = 0;
     let totalTaxes = 0;
@@ -61,8 +63,16 @@
         medicareTaxes = fica[1];
 
         // Update tax info
-        totalTaxes = incomeTaxes + socialSecurityTaxes + medicareTaxes;
+        totalTaxes = incomeTaxes + socialSecurityTaxes + medicareTaxes - nonRefundableTaxCredit;
+        if (totalTaxes < 0) {
+            totalTaxes = 0;
+        }
         afterTaxIncome = grossIncome - totalTaxes;
+        totalTaxes -= refundableTaxCredit;
+        if (totalTaxes < 0) {
+            afterTaxIncome -= totalTaxes;
+            totalTaxes = 0;
+        }
 
         // Return grossIncome, which prevents variable from being changed on form submission
         return grossIncome;
@@ -74,6 +84,10 @@
   <form on:submit|preventDefault={() => grossIncome = calcTaxes()}>
       <label for="fname">Yearly Income:</label>
       <input type="number" step=0.01 class = "income-entry" bind:value={grossIncome} on:input={calcTaxes}><br><br>
+      <label for="fname">Refundable Tax Credit:</label>
+      <input type="number" step=0.01 class = "refundable-entry" bind:value={refundableTaxCredit} on:input={calcTaxes}>
+      <label for="fname">Nonrefundable Tax Credit:</label>
+      <input type="number" step=0.01 class = "nonrefundable-entry" bind:value={nonRefundableTaxCredit} on:input={calcTaxes}><br><br>
       <label for="pin">Fiscal Year:</label>
       <select bind:value={year} on:change={calcTaxes}>
           {#each taxData.supportedYears as supportedYear}


### PR DESCRIPTION
### Background: 
A tax credit is a tax incentive allowing taxpayers to reduce the taxes they need to pay. If a taxpayer has an initial tax liability that is smaller than their refundable tax credit, then the government refunds the taxpayer the difference. If the tax credit is non-refundable, the taxpayer would owe nothing.

### Changes:
All changes were made in App.svelte (no helper methods were created for this issue). First, two new variables were created - refundableTaxCredit and nonRefundableTaxCredit. These variables are taken in through two separate user inputs. In calcTaxes, nonRefundableTaxCredit is subtracted from totalTaxes. If totalTaxes is less than zero (i.e. the nonrefundable tax credit is greater than the tax liability), then totalTaxes becomes 0. Next, refundableTaxCredit is subtracted from totalTaxes. If totalTaxes is less than zero (i.e. the refundable tax credit is greater than the tax liability and the taxpayer must be refunded), then totalTaxes becomes 0 and the difference is added to afterIncomeTax.

### Testing:
Below is what the total taxes paid would be without any credit back for an income of $100,000: 
<img width="833" alt="Screenshot 2023-04-25 at 2 26 03 PM" src="https://user-images.githubusercontent.com/115904810/234407685-f6372adb-4588-4af0-b613-a81b2e461b2f.png">

If the user has $200 refundable tax credit and $100 nonrefundable tax credit,  the total taxes paid would be $300 less: 
<img width="833" alt="Screenshot 2023-04-25 at 2 28 17 PM" src="https://user-images.githubusercontent.com/115904810/234408053-5690a858-fc96-4f20-b17b-ba6a2dcb5929.png">

If the user has more refundable credit than tax liability, the difference is refunded to their after tax income: 
<img width="833" alt="Screenshot 2023-04-25 at 2 29 26 PM" src="https://user-images.githubusercontent.com/115904810/234408264-dfaa9d59-5e95-4377-a1ef-b39d3b013f25.png">